### PR TITLE
Fix meta info for last-48-hours report.

### DIFF
--- a/reports/reports.json
+++ b/reports/reports.json
@@ -36,8 +36,8 @@
         "end-date": "today"
       },
       "meta": {
-        "name": "Today",
-        "description": "Today's visits for all sites."
+        "name": "Last 48 Hours",
+        "description": "Last 48 hours of visits for all sites."
       }
     },
     {


### PR DESCRIPTION
This report has incorrect `meta` info.
