### PR TITLE
Adds a realtime-pageviews report.

### DIFF
--- a/reports/reports.json
+++ b/reports/reports.json
@@ -13,6 +13,20 @@
       }
     },
     {
+      "name": "realtime-pageviews",
+      "frequency": "realtime",
+      "realtime": true,
+      "query": {
+        "metrics": ["rt:pageViews"],
+        "dimensions": ["rt:minutesAgo"],
+        "max-results": "1440"
+      },
+      "meta": {
+        "name": "Page Views by Minute",
+        "description": "Page views for the past day, by minute."
+      }
+    },
+    {
       "name": "today",
       "frequency": "realtime",
       "query": {


### PR DESCRIPTION
### WHAT

Adds a `realtime-pageviews` report, which returns a list of page views (via the realtime api) by minute, for the past day (ie 1,440 mins):

``` json
  ...
 "data": [
    {
      "rt:minutesAgo": "01",
      "rt:pageViews": "3"
    },
    {
      "rt:minutesAgo": "02",
      "rt:pageViews": "5"
    },
    {
      "rt:minutesAgo": "3",
      "rt:pageViews": "2"
    },
    {
      "rt:minutesAgo": "04",
      "rt:pageViews": "3"
    }
  ],
  ... 
```
### WHY

I think it'd be cool to include a line graph in the UI for visitors over the past day. I couldn't get `rt:activeUsers` to work here, but `rt:pageViews` seems like the next best thing. Could be fun to show the amplitude of traffic over the course of a day.
